### PR TITLE
Fix logo and guest banner layout

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -13,8 +13,8 @@ body {
 #logo {
   background-color: transparent;
   position: absolute;
-  bottom: 37px;
-  left: 45px;
+  top: 10px;
+  left: 15px;
   width: 55px;
   height: auto;
   z-index: 1000;
@@ -22,17 +22,17 @@ body {
 }
 
 #grafico-invitado-rol {
-  background-color: trasparent;
+  background-color: transparent;
   display: flex;
   /*flex-direction: column;*/
   position: absolute;
-  left: 0px;
+  left: 15px;
   bottom: 0px;
-  width: 100%;
+  width: 70%;
   height: 90px;
   transition: all 0.3s ease-in-out;
   border-radius: 5px 0 5px 0;
-z-index: 1;
+  z-index: 1;
 }
 
 #grafico-invitado-rol h1, #grafico-invitado-rol h2 {


### PR DESCRIPTION
## Summary
- Reposition the logo to the top-left to avoid clashing with the guest role banner
- Restrict guest role banner to 70% width and align it with a left margin for clear spacing

## Testing
- `npx stylelint styles.css` *(fails: Need to install stylelint)*
- `npm test` *(fails: package.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_689102dedaa48333947c8554cadd6238